### PR TITLE
Add first test react component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ treeherder/media/
 treeherder/static/
 treeherder/webapp/log_cache/
 ui/js/config/local.conf.js
-
+# babel will generate js files from jsx files under ui/js/components/
+ui/js/componenents/*.js
 # supervisor
 .nfs*
 *.pid

--- a/ui/index.html
+++ b/ui/index.html
@@ -84,6 +84,9 @@
         <script src="js/directives/treeherder/resultsets.js"></script>
         <script src="js/directives/treeherder/top_nav_bar.js"></script>
         <script src="js/directives/treeherder/bottom_nav_panel.js"></script>
+
+        <!-- React Components -->
+        <script src="js/components/test.js"></script>
         <!-- Main services -->
 
         <script src="js/services/main.js"></script>
@@ -111,7 +114,6 @@
         <script src="js/models/user.js"></script>
         <script src="js/models/error.js"></script>
         <script src="js/models/failure_lines.js"></script>
-        <script src="js/models/react_model.js" type="text/babel"></script>
         <script src="js/perf.js"></script>
         <!-- Controllers -->
         <script src="js/controllers/main.js"></script>

--- a/ui/js/components/test.jsx
+++ b/ui/js/components/test.jsx
@@ -1,0 +1,7 @@
+treeherder.service('ThReactTest', function() {
+    this.component = React.createClass({
+      render: function() {
+        return <div>Hello {this.props.name}</div>;
+      }
+    });
+});

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -5,13 +5,13 @@ treeherder.directive('thCloneJobs', [
     'thServiceDomain', 'thResultStatusInfo', 'thEvents', 'thAggregateIds',
     'thJobFilters', 'thResultStatusObject', 'ThResultSetStore',
     'ThJobModel', 'linkifyBugsFilter', 'thResultStatus', 'thPlatformName',
-    'thJobSearchStr', 'thNotify', '$timeout', "ThReactModel",
+    'thJobSearchStr', 'thNotify', '$timeout', 'ThReactTest',
     function(
         $rootScope, $http, ThLog, thUrl, thCloneHtml,
         thServiceDomain, thResultStatusInfo, thEvents, thAggregateIds,
         thJobFilters, thResultStatusObject, ThResultSetStore,
         ThJobModel, linkifyBugsFilter, thResultStatus, thPlatformName,
-        thJobSearchStr, thNotify, $timeout, ThReactModel){
+        thJobSearchStr, thNotify, $timeout, ThReactTest){
 
         var $log = new ThLog("thCloneJobs");
 
@@ -899,7 +899,7 @@ treeherder.directive('thCloneJobs', [
 
         var generateJobElements = function(resultsetAggregateId, resultset) {
             ReactDOM.render(
-              React.createElement(ThReactModel.Hello, {name: "Let's ReactJS!"}),
+              React.createElement(ThReactTest.component, {name: "Let's ReactJS!"}),
               document.getElementsByClassName("job-list")[0]
             );
             var tableEl = $('#' + resultsetAggregateId);


### PR DESCRIPTION
I believe angular and babel-browse don't play well together. Angular seems to ignore the content of script tags with type text/babel, so you need to install babel (globally) and babel-preset-react on your machine and then run

``` bash
babel --presets react --watch ui/js/components --out-dir ui/js/components
```

and the webserver in a separate shell.
The alternative, which doesn't require babel at all, is to use ReactDom directly.
